### PR TITLE
Add less term cap vars for man page coloring

### DIFF
--- a/.config/zsh/rc.d/05-env.zsh
+++ b/.config/zsh/rc.d/05-env.zsh
@@ -33,3 +33,13 @@ if command -v brew > /dev/null; then
   # only for those commands that zsh doesn't already know how to complete.
   fpath+=( $HOMEBREW_PREFIX/share/zsh/site-functions )
 fi
+
+# Adding color to man pages is accomplished by setting these environment variables
+# using 'less' env vars (format is '\e[<effect>;<color>m', or '\e[<effect>;<bg>;<fg>m')
+export LESS_TERMCAP_mb=$'\e[01;34m'      # mb:=start blink-mode (bold,blue)
+export LESS_TERMCAP_md=$'\e[01;34m'      # md:=start bold-mode (bold,blue)
+export LESS_TERMCAP_so=$'\e[00;47;30m'   # so:=start standout-mode (white bg, black fg)
+export LESS_TERMCAP_us=$'\e[04;35m'      # us:=start underline-mode (underline magenta)
+export LESS_TERMCAP_se=$'\e[0m'          # se:=end standout-mode
+export LESS_TERMCAP_ue=$'\e[0m'          # ue:=end underline-mode
+export LESS_TERMCAP_me=$'\e[0m'          # me:=end modes


### PR DESCRIPTION
Added this handy block of code, that gives Zsh users the same kind of man page coloring they get by default in Fish.

```zsh
# Adding color to your man pages is accomplished by setting these environment variables
# using 'less' env vars (format is '\e[<effect>;<color>m', or '\e[<effect>;<bg>;<fg>m')
export LESS_TERMCAP_mb=$'\e[01;34m'      # mb:=start blink-mode (bold,blue)
export LESS_TERMCAP_md=$'\e[01;34m'      # md:=start bold-mode (bold,blue)
export LESS_TERMCAP_so=$'\e[00;47;30m'   # so:=start standout-mode (white bg, black fg)
export LESS_TERMCAP_us=$'\e[04;35m'      # us:=start underline-mode (underline magenta)
export LESS_TERMCAP_se=$'\e[0m'          # se:=end standout-mode
export LESS_TERMCAP_ue=$'\e[0m'          # ue:=end underline-mode
export LESS_TERMCAP_me=$'\e[0m'          # me:=end modes
```
